### PR TITLE
Backstretch light theme fix

### DIFF
--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -60,12 +60,15 @@ $(document).ready(function(){
     });
 
     // changed by br 2016/01/22 to slow down changing image frames on silde display
+    // Edited to move $('body').addClass('home'); up and put if statement around backstretch code. 3/25/2016 JB
     if(typeof(cms) !== 'undefined' && cms.home === 'home'){
-        $.backstretch(cms.slides, {
-            fade: 750,
-            duration: 5000     // br extend time from 2000 to 5000 ms
-        });
-        $('body').addClass('home');
+    	$('body').addClass('home');
+    	if($('.backstretch').length) {
+			$.backstretch(cms.slides, {
+				fade: 750,
+				duration: 5000     // br extend time from 2000 to 5000 ms
+			});
+        }
     }
 
     //image galleries on projects
@@ -91,43 +94,39 @@ $(document).ready(function(){
         });
     });
 
-    var group = $("ol.top-menu").sortable(
-        {
-            group: 'top-menu',
-            onDrop: function  (item, targetContainer, _super) {
-                var clonedItem = $('<li/>').css({height: 0})
-                item.before(clonedItem)
-                clonedItem.animate({'height': item.height()})
+    var group = $("ol.top-menu").sortable({
+		group: 'top-menu',
+		onDrop: function  (item, targetContainer, _super) {
+			var clonedItem = $('<li/>').css({height: 0})
+			item.before(clonedItem)
+			clonedItem.animate({'height': item.height()})
 
-                item.animate(clonedItem.position(), function  () {
-                    clonedItem.detach()
-                    _super(item)
-                });
-                var data = group.sortable("serialize").get();
+			item.animate(clonedItem.position(), function  () {
+				clonedItem.detach()
+				_super(item)
+			});
+			var data = group.sortable("serialize").get();
 
-                $("body").data('top_menu', data);
+			$("body").data('top_menu', data);
 
-            },
-            onDragStart: function ($item, container, _super) {
-                var offset = $item.offset(),
-                    pointer = container.rootGroup.pointer
+		},
+		onDragStart: function ($item, container, _super) {
+			var offset = $item.offset(),
+				pointer = container.rootGroup.pointer
 
-                adjustment = {
-                    left: pointer.left - offset.left,
-                    top: pointer.top - offset.top
-                }
+			adjustment = {
+				left: pointer.left - offset.left,
+				top: pointer.top - offset.top
+			}
 
-                _super($item, container)
-            },
-            onDrag: function ($item, position) {
-                $item.css({
-                    left: position.left - adjustment.left,
-                    top: position.top - adjustment.top
-                })
-            }
+			_super($item, container)
+		},
+		onDrag: function ($item, position) {
+			$item.css({
+				left: position.left - adjustment.left,
+				top: position.top - adjustment.top
+			})
+		}
 
-        }
-    );
-
-
+	});
 });


### PR DESCRIPTION
Backstretch is a script for the slideshow on the dark theme. If it’s
not being used, like on the light theme, the backstretch code in app.js
throws an error and conflicts with other scripts. This code change adds
an if statement that looks to see if the .backstretch class exists and
executes if it does. This fixes 3 issues in one. Now the “home” class
shows up on the light theme home page in the source code.